### PR TITLE
perf: RISC-V: fix IRQ detection on T-Head C908

### DIFF
--- a/arch/riscv/errata/thead/errata.c
+++ b/arch/riscv/errata/thead/errata.c
@@ -125,10 +125,6 @@ static bool errata_probe_pmu(unsigned int stage,
 	if (!IS_ENABLED(CONFIG_ERRATA_THEAD_PMU))
 		return false;
 
-	/* target-c9xx cores report arch_id and impid as 0 */
-	if (arch_id != 0 || impid != 0)
-		return false;
-
 	if (stage == RISCV_ALTERNATIVES_EARLY_BOOT)
 		return false;
 

--- a/drivers/perf/riscv_pmu_sbi.c
+++ b/drivers/perf/riscv_pmu_sbi.c
@@ -811,9 +811,7 @@ static int pmu_sbi_setup_irqs(struct riscv_pmu *pmu, struct platform_device *pde
 		riscv_pmu_irq_num = RV_IRQ_PMU;
 		riscv_pmu_use_irq = true;
 	} else if (IS_ENABLED(CONFIG_ERRATA_THEAD_PMU) &&
-		   riscv_cached_mvendorid(0) == THEAD_VENDOR_ID &&
-		   riscv_cached_marchid(0) == 0 &&
-		   riscv_cached_mimpid(0) == 0) {
+		   riscv_cached_mvendorid(0) == THEAD_VENDOR_ID) {
 		riscv_pmu_irq_num = THEAD_C9XX_RV_IRQ_PMU;
 		riscv_pmu_use_irq = true;
 	}


### PR DESCRIPTION
Cherry-picked from under view patch from the link: https://lore.kernel.org/linux-riscv/20240311063018.1886757-1-dqfext@gmail.com/

This patch can be used as a workaround to allow `perf record` to run on K230. It will be suitable for RVV 1.0 software profiling now. However, this patch may need refactoring to parse dts to choose thead errata, or it can't be merged to the mainline.